### PR TITLE
Add usecase target for manual context propagation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,9 @@ import PackageDescription
 
 let package = Package(
     name: "gsoc-swift-tracing",
+    products: [
+        .library(name: "ContextPropagation", targets: ["ContextPropagation"])
+    ],
     targets: [
         .target(name: "ContextPropagation"),
         .testTarget(name: "ContextPropagationTests", dependencies: ["ContextPropagation"])

--- a/Sources/ContextPropagation/Context.swift
+++ b/Sources/ContextPropagation/Context.swift
@@ -11,7 +11,7 @@ public struct Context {
         dict[ObjectIdentifier(key)] = ValueContainer(value: value)
     }
 
-    public mutating func extract<Key: ContextKey>(_ key: Key.Type) -> Key.Value? {
+    public func extract<Key: ContextKey>(_ key: Key.Type) -> Key.Value? {
         dict[ObjectIdentifier(key)]?.forceUnwrap(key)
     }
 

--- a/Sources/ContextPropagation/InstrumentationMiddleware.swift
+++ b/Sources/ContextPropagation/InstrumentationMiddleware.swift
@@ -1,0 +1,28 @@
+public protocol InstrumentationMiddlewareProtocol {
+    associatedtype ExtractFrom
+    associatedtype InjectInto
+
+    func extract(from: ExtractFrom, into context: inout Context)
+    func inject(from context: Context, into: inout InjectInto)
+}
+
+public struct InstrumentationMiddleware<InjectInto, ExtractFrom>: InstrumentationMiddlewareProtocol {
+    private let extract: (ExtractFrom, inout Context) -> Void
+    private let inject: (Context, inout InjectInto) -> Void
+
+    public init(
+        extract: @escaping (ExtractFrom, inout Context) -> Void,
+        inject: @escaping (Context, inout InjectInto) -> Void
+    ) {
+        self.extract = extract
+        self.inject = inject
+    }
+
+    public func extract(from: ExtractFrom, into context: inout Context) {
+        self.extract(from, &context)
+    }
+
+    public func inject(from context: Context, into: inout InjectInto) {
+        self.inject(context, &into)
+    }
+}

--- a/UseCases/.gitignore
+++ b/UseCases/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+.swiftpm

--- a/UseCases/Package.swift
+++ b/UseCases/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:5.2
+import PackageDescription
+
+let package = Package(
+    name: "use-cases",
+    products: [
+        .executable(name: "ManualContextPropagation", targets: ["ManualContextPropagation"])
+    ],
+    dependencies: [
+        .package(path: "../")
+    ],
+    targets: [
+        .target(name: "ManualContextPropagation", dependencies: [
+            .product(name: "ContextPropagation", package: "gsoc-swift-tracing")
+        ])
+    ]
+)

--- a/UseCases/Sources/ManualContextPropagation/main.swift
+++ b/UseCases/Sources/ManualContextPropagation/main.swift
@@ -14,29 +14,6 @@ let server = FakeHTTPServer(
 print("=== Receive HTTP request on server ===")
 server.receive(FakeHTTPRequest(path: "/", headers: []))
 
-// MARK: - Instrumentation Middleware
-
-protocol InstrumentationMiddlewareProtocol {
-    associatedtype ExtractFrom
-    associatedtype InjectInto
-
-    func extract(from: ExtractFrom, into context: inout Context)
-    func inject(from context: Context, into: inout InjectInto)
-}
-
-struct InstrumentationMiddleware<InjectInto, ExtractFrom>: InstrumentationMiddlewareProtocol {
-    let extract: (ExtractFrom, inout Context) -> Void
-    let inject: (Context, inout InjectInto) -> Void
-
-    func extract(from: ExtractFrom, into context: inout Context) {
-        self.extract(from, &context)
-    }
-
-    func inject(from context: Context, into: inout InjectInto) {
-        self.inject(context, &into)
-    }
-}
-
 // MARK: - Fake HTTP Server
 
 typealias HTTPHeaders = [(String, String)]

--- a/UseCases/Sources/ManualContextPropagation/main.swift
+++ b/UseCases/Sources/ManualContextPropagation/main.swift
@@ -1,0 +1,130 @@
+import ContextPropagation
+
+// MARK: - Demo
+
+let server = FakeHTTPServer(
+    instrumentationMiddlewares: [FakeTracer.Middleware(tracer: FakeTracer())]
+) { context, request, client -> FakeHTTPResponse in
+    print("=== Perform subsequent request ===")
+    let outgoingRequest = FakeHTTPRequest(path: "/other-service", headers: [("Content-Type", "application/json")])
+    client.performRequest(context, request: outgoingRequest)
+    return FakeHTTPResponse()
+}
+
+print("=== Receive HTTP request on server ===")
+server.receive(FakeHTTPRequest(path: "/", headers: []))
+
+// MARK: - Instrumentation Middleware
+
+protocol InstrumentationMiddlewareProtocol {
+    associatedtype ExtractFrom
+    associatedtype InjectInto
+
+    func extract(from: ExtractFrom, into context: inout Context)
+    func inject(from context: Context, into: inout InjectInto)
+}
+
+struct InstrumentationMiddleware<InjectInto, ExtractFrom>: InstrumentationMiddlewareProtocol {
+    let extract: (ExtractFrom, inout Context) -> Void
+    let inject: (Context, inout InjectInto) -> Void
+
+    func extract(from: ExtractFrom, into context: inout Context) {
+        self.extract(from, &context)
+    }
+
+    func inject(from context: Context, into: inout InjectInto) {
+        self.inject(context, &into)
+    }
+}
+
+// MARK: - Fake HTTP Server
+
+typealias HTTPHeaders = [(String, String)]
+
+struct FakeHTTPRequest {
+    let path: String
+    var headers: HTTPHeaders
+}
+
+struct FakeHTTPResponse {}
+
+typealias HTTPHeadersIntrumentationMiddleware = InstrumentationMiddleware<HTTPHeaders, HTTPHeaders>
+
+struct FakeHTTPServer {
+    typealias Handler = (Context, FakeHTTPRequest, FakeHTTPClient) -> FakeHTTPResponse
+
+    private let instrumentationMiddlewares: [InstrumentationMiddleware<HTTPHeaders, HTTPHeaders>]
+    private let catchAllHandler: Handler
+    private let client: FakeHTTPClient
+
+    init<M: InstrumentationMiddlewareProtocol>(
+        instrumentationMiddlewares: [M],
+        catchAllHandler: @escaping Handler
+    ) where M.InjectInto == HTTPHeaders, M.ExtractFrom == HTTPHeaders {
+        self.instrumentationMiddlewares = instrumentationMiddlewares.map {
+            InstrumentationMiddleware(extract: $0.extract, inject: $0.inject)
+        }
+        self.catchAllHandler = catchAllHandler
+        self.client = FakeHTTPClient(instrumentationMiddlewares: instrumentationMiddlewares)
+    }
+
+    func receive(_ request: FakeHTTPRequest) {
+        var context = Context()
+        print("\(String(describing: Self.self)): Extracting context values from request headers into context")
+        instrumentationMiddlewares.forEach { $0.extract(from: request.headers, into: &context) }
+        _ = catchAllHandler(context, request, client)
+    }
+}
+
+// MARK: - Fake HTTP Client
+
+struct FakeHTTPClient {
+    private let instrumentationMiddlewares: [InstrumentationMiddleware<HTTPHeaders, HTTPHeaders>]
+
+    init<M: InstrumentationMiddlewareProtocol>(
+        instrumentationMiddlewares: [M]
+    ) where M.InjectInto == HTTPHeaders, M.ExtractFrom == HTTPHeaders {
+        self.instrumentationMiddlewares = instrumentationMiddlewares.map {
+            InstrumentationMiddleware(extract: $0.extract, inject: $0.inject)
+        }
+    }
+
+    func performRequest(_ context: Context, request: FakeHTTPRequest) {
+        var request = request
+        print("\(String(describing: Self.self)): Injecting context values into request headers")
+        instrumentationMiddlewares.forEach { $0.inject(from: context, into: &request.headers) }
+        print(request)
+    }
+}
+
+// MARK: - Fake Tracer
+
+struct FakeTracer {
+    func generateTraceID() -> String {
+        "3f59ef6fe1fe2b12dd84ec1452696599"
+    }
+
+    struct Middleware: InstrumentationMiddlewareProtocol {
+        private let tracer: FakeTracer
+
+        init(tracer: FakeTracer) {
+            self.tracer = tracer
+        }
+
+        func extract(from headers: HTTPHeaders, into context: inout Context) {
+            let traceID = headers.first(where: { $0.0 == FakeTraceID.headerName })?.1 ?? tracer.generateTraceID()
+            context.inject(FakeTraceID.self, value: traceID)
+        }
+
+        func inject(from context: Context, into headers: inout HTTPHeaders) {
+            guard let traceID = context.extract(FakeTraceID.self) else { return }
+            headers.append((FakeTraceID.headerName, traceID))
+        }
+    }
+
+    private enum FakeTraceID: ContextKey {
+        typealias Value = String
+
+        static let headerName = "fake-trace-id"
+    }
+}


### PR DESCRIPTION
Adds a `ManualContextPropagation` use-case target simulating the following actions:

- Handle incoming fake request
- Propagate context
  - Handle request by making subsequent request
  - Populate outgoing request headers with trace ID from `Context`

Closes #6 