### PR TITLE
Add usecase for manual context propagation with AsyncHTTPClient

### DIFF
--- a/UseCases/Package.resolved
+++ b/UseCases/Package.resolved
@@ -1,0 +1,43 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "async-http-client",
+        "repositoryURL": "https://github.com/swift-server/async-http-client.git",
+        "state": {
+          "branch": null,
+          "revision": "037b70291941fe43de668066eb6fb802c5e181d2",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "package": "swift-nio",
+        "repositoryURL": "https://github.com/apple/swift-nio.git",
+        "state": {
+          "branch": null,
+          "revision": "c5fa0b456524cd73dc3ddbb263d4f46c20b86ca3",
+          "version": "2.17.0"
+        }
+      },
+      {
+        "package": "swift-nio-extras",
+        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
+        "state": {
+          "branch": null,
+          "revision": "7cd24c0efcf9700033f671b6a8eaa64a77dd0b72",
+          "version": "1.5.1"
+        }
+      },
+      {
+        "package": "swift-nio-ssl",
+        "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
+        "state": {
+          "branch": null,
+          "revision": "10e0e17dd47b594c3d864a063f343d716e33e5c1",
+          "version": "2.7.3"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/UseCases/Package.swift
+++ b/UseCases/Package.swift
@@ -4,14 +4,20 @@ import PackageDescription
 let package = Package(
     name: "use-cases",
     products: [
-        .executable(name: "ManualContextPropagation", targets: ["ManualContextPropagation"])
+        .executable(name: "ManualContextPropagation", targets: ["ManualContextPropagation"]),
+        .executable(name: "ManualAsyncHTTPClient", targets: ["ManualAsyncHTTPClient"])
     ],
     dependencies: [
-        .package(path: "../")
+        .package(path: "../"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.1.1")
     ],
     targets: [
         .target(name: "ManualContextPropagation", dependencies: [
             .product(name: "ContextPropagation", package: "gsoc-swift-tracing")
+        ]),
+        .target(name: "ManualAsyncHTTPClient", dependencies: [
+            .product(name: "ContextPropagation", package: "gsoc-swift-tracing"),
+            .product(name: "AsyncHTTPClient", package: "async-http-client")
         ])
     ]
 )

--- a/UseCases/Sources/ManualAsyncHTTPClient/main.swift
+++ b/UseCases/Sources/ManualAsyncHTTPClient/main.swift
@@ -10,8 +10,7 @@ let server = FakeHTTPServer(
         url: "https://swift.org",
         headers: ["Accept": "application/json"]
     )
-    client.execute(context, request: outgoingRequest)
-//    client.execute(request: outgoingRequest, inContext: context)
+    client.execute(request: outgoingRequest, context: context)
     return FakeHTTPResponse()
 }
 
@@ -32,15 +31,10 @@ struct InstrumentedHTTPClient {
         }
     }
 
-    func execute(request: HTTPClient.Request, inContext context: Context) {
-        execute(context, request: request)
-    }
-
-    func execute(_ context: Context, request: HTTPClient.Request) {
+    func execute(request: HTTPClient.Request, context: Context) {
         var request = request
         instrumentationMiddlewares.forEach { $0.inject(from: context, into: &request.headers) }
         print(request.headers)
-//        client.execute(request: request)
     }
 }
 

--- a/UseCases/Sources/ManualAsyncHTTPClient/main.swift
+++ b/UseCases/Sources/ManualAsyncHTTPClient/main.swift
@@ -18,9 +18,9 @@ let server = FakeHTTPServer(
 print("=== Receive HTTP request on server ===")
 server.receive(try! HTTPClient.Request(url: "https://swift.org"))
 
-// MARK: - InstrumentingHTTPClient
+// MARK: - InstrumentedHTTPClient
 
-struct InstrumentingHTTPClient {
+struct InstrumentedHTTPClient {
     private let client = HTTPClient(eventLoopGroupProvider: .createNew)
     private let instrumentationMiddlewares: [InstrumentationMiddleware<HTTPHeaders, HTTPHeaders>]
 
@@ -51,11 +51,11 @@ struct FakeHTTPResponse {}
 private typealias HTTPHeadersInstrumentationMiddleware = InstrumentationMiddleware<HTTPHeaders, HTTPHeaders>
 
 struct FakeHTTPServer {
-    typealias Handler = (Context, HTTPClient.Request, InstrumentingHTTPClient) -> FakeHTTPResponse
+    typealias Handler = (Context, HTTPClient.Request, InstrumentedHTTPClient) -> FakeHTTPResponse
 
     private let instrumentationMiddlewares: [InstrumentationMiddleware<HTTPHeaders, HTTPHeaders>]
     private let catchAllHandler: Handler
-    private let client: InstrumentingHTTPClient
+    private let client: InstrumentedHTTPClient
 
     init<M: InstrumentationMiddlewareProtocol>(
         instrumentationMiddlewares: [M],
@@ -64,7 +64,7 @@ struct FakeHTTPServer {
         self.instrumentationMiddlewares = instrumentationMiddlewares.map {
             InstrumentationMiddleware(extract: $0.extract, inject: $0.inject)
         }
-        self.client = InstrumentingHTTPClient(instrumentationMiddlewares: instrumentationMiddlewares)
+        self.client = InstrumentedHTTPClient(instrumentationMiddlewares: instrumentationMiddlewares)
         self.catchAllHandler = catchAllHandler
     }
 

--- a/UseCases/Sources/ManualAsyncHTTPClient/main.swift
+++ b/UseCases/Sources/ManualAsyncHTTPClient/main.swift
@@ -1,61 +1,27 @@
+import AsyncHTTPClient
 import ContextPropagation
-
-// MARK: - Demo
+import NIOHTTP1
 
 let server = FakeHTTPServer(
     instrumentationMiddlewares: [FakeTracer.Middleware(tracer: FakeTracer())]
 ) { context, request, client -> FakeHTTPResponse in
     print("=== Perform subsequent request ===")
-    let outgoingRequest = FakeHTTPRequest(path: "/other-service", headers: [("Content-Type", "application/json")])
-    client.performRequest(context, request: outgoingRequest)
+    let outgoingRequest = try! HTTPClient.Request(
+        url: "https://swift.org",
+        headers: ["Accept": "application/json"]
+    )
+    client.execute(context, request: outgoingRequest)
+//    client.execute(request: outgoingRequest, inContext: context)
     return FakeHTTPResponse()
 }
 
 print("=== Receive HTTP request on server ===")
-server.receive(FakeHTTPRequest(path: "/", headers: []))
+server.receive(try! HTTPClient.Request(url: "https://swift.org"))
 
-// MARK: - Fake HTTP Server
+// MARK: - InstrumentingHTTPClient
 
-typealias HTTPHeaders = [(String, String)]
-
-struct FakeHTTPRequest {
-    let path: String
-    var headers: HTTPHeaders
-}
-
-struct FakeHTTPResponse {}
-
-typealias HTTPHeadersIntrumentationMiddleware = InstrumentationMiddleware<HTTPHeaders, HTTPHeaders>
-
-struct FakeHTTPServer {
-    typealias Handler = (Context, FakeHTTPRequest, FakeHTTPClient) -> FakeHTTPResponse
-
-    private let instrumentationMiddlewares: [InstrumentationMiddleware<HTTPHeaders, HTTPHeaders>]
-    private let catchAllHandler: Handler
-    private let client: FakeHTTPClient
-
-    init<M: InstrumentationMiddlewareProtocol>(
-        instrumentationMiddlewares: [M],
-        catchAllHandler: @escaping Handler
-    ) where M.InjectInto == HTTPHeaders, M.ExtractFrom == HTTPHeaders {
-        self.instrumentationMiddlewares = instrumentationMiddlewares.map {
-            InstrumentationMiddleware(extract: $0.extract, inject: $0.inject)
-        }
-        self.catchAllHandler = catchAllHandler
-        self.client = FakeHTTPClient(instrumentationMiddlewares: instrumentationMiddlewares)
-    }
-
-    func receive(_ request: FakeHTTPRequest) {
-        var context = Context()
-        print("\(String(describing: Self.self)): Extracting context values from request headers into context")
-        instrumentationMiddlewares.forEach { $0.extract(from: request.headers, into: &context) }
-        _ = catchAllHandler(context, request, client)
-    }
-}
-
-// MARK: - Fake HTTP Client
-
-struct FakeHTTPClient {
+struct InstrumentingHTTPClient {
+    private let client = HTTPClient(eventLoopGroupProvider: .createNew)
     private let instrumentationMiddlewares: [InstrumentationMiddleware<HTTPHeaders, HTTPHeaders>]
 
     init<M: InstrumentationMiddlewareProtocol>(
@@ -66,11 +32,47 @@ struct FakeHTTPClient {
         }
     }
 
-    func performRequest(_ context: Context, request: FakeHTTPRequest) {
+    func execute(request: HTTPClient.Request, inContext context: Context) {
+        execute(context, request: request)
+    }
+
+    func execute(_ context: Context, request: HTTPClient.Request) {
         var request = request
-        print("\(String(describing: Self.self)): Injecting context values into request headers")
         instrumentationMiddlewares.forEach { $0.inject(from: context, into: &request.headers) }
-        print(request)
+        print(request.headers)
+//        client.execute(request: request)
+    }
+}
+
+// MARK: - Fake HTTP Server
+
+struct FakeHTTPResponse {}
+
+private typealias HTTPHeadersInstrumentationMiddleware = InstrumentationMiddleware<HTTPHeaders, HTTPHeaders>
+
+struct FakeHTTPServer {
+    typealias Handler = (Context, HTTPClient.Request, InstrumentingHTTPClient) -> FakeHTTPResponse
+
+    private let instrumentationMiddlewares: [InstrumentationMiddleware<HTTPHeaders, HTTPHeaders>]
+    private let catchAllHandler: Handler
+    private let client: InstrumentingHTTPClient
+
+    init<M: InstrumentationMiddlewareProtocol>(
+        instrumentationMiddlewares: [M],
+        catchAllHandler: @escaping Handler
+    ) where M.InjectInto == HTTPHeaders, M.ExtractFrom == HTTPHeaders {
+        self.instrumentationMiddlewares = instrumentationMiddlewares.map {
+            InstrumentationMiddleware(extract: $0.extract, inject: $0.inject)
+        }
+        self.client = InstrumentingHTTPClient(instrumentationMiddlewares: instrumentationMiddlewares)
+        self.catchAllHandler = catchAllHandler
+    }
+
+    func receive(_ request: HTTPClient.Request) {
+        var context = Context()
+        print("\(String(describing: Self.self)): Extracting context values from request headers into context")
+        instrumentationMiddlewares.forEach { $0.extract(from: request.headers, into: &context) }
+        _ = catchAllHandler(context, request, client)
     }
 }
 
@@ -95,7 +97,7 @@ private struct FakeTracer {
 
         func inject(from context: Context, into headers: inout HTTPHeaders) {
             guard let traceID = context.extract(FakeTraceID.self) else { return }
-            headers.append((FakeTraceID.headerName, traceID))
+            headers.add(name: FakeTraceID.headerName, value: traceID)
         }
     }
 


### PR DESCRIPTION
## New use case

Adds a `ManualAsyncHTTPClient` use-case target that uses a `FakeHTTPServer` and `FakeTracer` to simulate the following steps.

- Handle incoming fake request
- Propagate context
  - Handle request by making subsequent request using `AsyncHTTPClient`
  - Populate outgoing request (`HTTPClient.Request`) headers with trace ID from `Context`

## Discussion

The `HTTPClient` integration is done by wrapping the client inside an `InstrumentingHTTPClient` struct that adds an `execute` method similar to the one of `AsyncHTTPClient` additionally receiving the context as an argument.

Wrapping `AsyncHTTPClient` in a struct is only a temporary solution to demonstrate without forking it what it's new, context-aware, API could look like.

Closes #8