### PR TITLE
+sanity #17 add sanity scripts (formatting, license)

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,7 +1,8 @@
 # file options
 
---swiftversion 5.1
+--swiftversion 5.2
 --exclude .build
+--exclude UseCases/.build
 
 # format options
 

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,16 @@
+# file options
+
+--swiftversion 5.1
+--exclude .build
+
+# format options
+
+--ifdef no-indent
+--patternlet inline
+--self insert
+--stripunusedargs closure-only
+--wraparguments before-first
+
+# rules
+
+--disable blankLinesAroundMark

--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@ This is a WIP collection of Swift libraries enabling Tracing for your Swift (Ser
 ## Discussions
 
 Discussions about this topic are **more than welcome**. During this project we'll use a mixture of [GitHub issues](https://github.com/slashmo/gsoc-swift-tracing/issues) and [Swift forum posts](https://forums.swift.org/c/server/serverdev/14).
+
+## Contributing
+
+Please make sure to run the `./scripts/sanity.sh` script when contributing, it checks formatting and similar things.
+
+You can make ensure it always is run and passes before you push by installing a pre-push hook with git:
+
+```
+echo './scripts/sanity.sh' > .git/hooks/pre-push
+```

--- a/Sources/ContextPropagation/Context.swift
+++ b/Sources/ContextPropagation/Context.swift
@@ -8,22 +8,22 @@ public struct Context {
     public init() {}
 
     public mutating func inject<Key: ContextKey>(_ key: Key.Type, value: Key.Value) {
-        dict[ObjectIdentifier(key)] = ValueContainer(value: value)
+        self.dict[ObjectIdentifier(key)] = ValueContainer(value: value)
     }
 
     public func extract<Key: ContextKey>(_ key: Key.Type) -> Key.Value? {
-        dict[ObjectIdentifier(key)]?.forceUnwrap(key)
+        self.dict[ObjectIdentifier(key)]?.forceUnwrap(key)
     }
 
     public mutating func remove<Key: ContextKey>(_ key: Key.Type) {
-        dict[ObjectIdentifier(key)] = nil
+        self.dict[ObjectIdentifier(key)] = nil
     }
 
     private struct ValueContainer {
         let value: Any
 
         func forceUnwrap<Key: ContextKey>(_ key: Key.Type) -> Key.Value {
-            value as! Key.Value
+            self.value as! Key.Value
         }
     }
 }

--- a/Sources/ContextPropagation/Instrumentation/InstrumentationMiddleware.swift
+++ b/Sources/ContextPropagation/Instrumentation/InstrumentationMiddleware.swift
@@ -15,8 +15,8 @@ public struct InstrumentationMiddleware<InjectInto, ExtractFrom>: Instrumentatio
         Middleware: InstrumentationMiddlewareProtocol,
         Middleware.InjectInto == InjectInto,
         Middleware.ExtractFrom == ExtractFrom {
-            self.extract = middleware.extract
-            self.inject = middleware.inject
+        self.extract = middleware.extract
+        self.inject = middleware.inject
     }
 
     public func extract(from: ExtractFrom, into context: inout Context) {

--- a/Sources/ContextPropagation/Instrumentation/MultiplexInstrumentationMiddleware.swift
+++ b/Sources/ContextPropagation/Instrumentation/MultiplexInstrumentationMiddleware.swift
@@ -14,10 +14,10 @@ public struct MultiplexInstrumentationMiddleware<InjectInto, ExtractFrom> {
 
 extension MultiplexInstrumentationMiddleware: InstrumentationMiddlewareProtocol {
     public func extract(from: ExtractFrom, into context: inout Context) {
-        middlewares.forEach { $0.extract(from: from, into: &context) }
+        self.middlewares.forEach { $0.extract(from: from, into: &context) }
     }
 
     public func inject(from context: Context, into: inout InjectInto) {
-        middlewares.forEach { $0.inject(from: context, into: &into) }
+        self.middlewares.forEach { $0.inject(from: context, into: &into) }
     }
 }

--- a/Tests/ContextPropagationTests/Instrumentation/InstrumentationMiddlewareTests.swift
+++ b/Tests/ContextPropagationTests/Instrumentation/InstrumentationMiddlewareTests.swift
@@ -5,7 +5,7 @@ final class InstrumentationMiddlewareTests: XCTestCase {
     func testMultiplexInvokesAllMiddleware() {
         let middleware = MultiplexInstrumentationMiddleware([
             InstrumentationMiddleware(FirstFakeTracer.Middleware()),
-            InstrumentationMiddleware(SecondFakeTracer.Middleware())
+            InstrumentationMiddleware(SecondFakeTracer.Middleware()),
         ])
 
         var context = Context()
@@ -20,7 +20,7 @@ final class InstrumentationMiddlewareTests: XCTestCase {
 
         XCTAssertEqual(subsequentRequestHeaders, [
             FirstFakeTracer.headerName: FirstFakeTracer.defaultTraceID,
-            SecondFakeTracer.headerName: SecondFakeTracer.defaultTraceID
+            SecondFakeTracer.headerName: SecondFakeTracer.defaultTraceID,
         ])
     }
 }
@@ -34,7 +34,6 @@ private struct FirstFakeTracer {
     static let defaultTraceID = UUID().uuidString
 
     struct Middleware: InstrumentationMiddlewareProtocol {
-
         func extract(from headers: [String: String], into context: inout Context) {
             let traceID = headers.first(where: { $0.key == FirstFakeTracer.headerName })?.value ?? FirstFakeTracer.defaultTraceID
             context.inject(FirstFakeTracer.TraceID.self, value: traceID)
@@ -55,7 +54,6 @@ private struct SecondFakeTracer {
     static let defaultTraceID = UUID().uuidString
 
     struct Middleware: InstrumentationMiddlewareProtocol {
-
         func extract(from headers: [String: String], into context: inout Context) {
             let traceID = headers.first(where: { $0.key == SecondFakeTracer.headerName })?.value ?? SecondFakeTracer.defaultTraceID
             context.inject(SecondFakeTracer.TraceID.self, value: traceID)

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# bash $here/validate_license_header.sh
+bash $here/validate_format.sh

--- a/scripts/validate_format.sh
+++ b/scripts/validate_format.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -u
+
+# verify that swiftformat is on the PATH
+command -v swiftformat >/dev/null 2>&1 || { echo >&2 "'swiftformat' could not be found. Please ensure it is installed and on the PATH."; exit 1; }
+
+printf "=> Checking format\n"
+FIRST_OUT="$(git status --porcelain)"
+# swiftformat does not scale so we loop ourselves
+shopt -u dotglob
+find Sources/* Tests/* -type d | while IFS= read -r d; do
+  printf "   * checking $d... "
+  out=$(swiftformat $d 2>&1)
+  SECOND_OUT="$(git status --porcelain)"
+  if [[ "$out" == *"error"*] && ["$out" != "*No eligible files" ]]; then
+    printf "\033[0;31merror!\033[0m\n"
+    echo $out
+    exit 1
+  fi
+  if [[ "$FIRST_OUT" != "$SECOND_OUT" ]]; then
+    printf "\033[0;31mformatting issues!\033[0m\n"
+    git --no-pager diff
+    exit 1
+  fi
+  printf "\033[0;32mokay.\033[0m\n"
+done


### PR DESCRIPTION
Simple formatting hook, similar to the one used in NIO and other projects.

I didn't add license validation yet. We'd eventually want the same "header" as we do in NIO and others: https://github.com/apple/swift-nio/blob/master/Tests/NIOTestUtilsTests/ByteToMessageDecoderVerifierTest%2BXCTest.swift#L1-L13 but didn't add it yet.

The settings inspired by NIO and some other projects where we use swiftformat, hope they're fine @slashmo 

// we're sticking to `SwiftFormat, version 0.44.6` in our builds nowadays AFAICS (docker images etc), so that's what this was formatted with.