### PR TITLE
Compile UseCases on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,3 +11,8 @@ jobs:
         uses: actions/checkout@v1
       - name: Build & Test
         run: swift test -c release --enable-test-discovery
+      - name: Compile UseCases
+        run: |
+          cd UseCases
+          swift package resolve
+          swift build


### PR DESCRIPTION
As discussed in #15, the `UseCases` package will now be compiled on the CI.

Closes #15 