### PR TITLE
Print keys in custom BaggageContext description

### DIFF
--- a/Sources/Baggage/BaggageContext.swift
+++ b/Sources/Baggage/BaggageContext.swift
@@ -63,6 +63,12 @@ public struct BaggageContext {
     }
 }
 
+extension BaggageContext: CustomStringConvertible {
+    public var description: String {
+        "\(Self.self)(keys: \(self._storage.map(\.key.name)))"
+    }
+}
+
 /// `BaggageContextKey`s are used as keys in a `BaggageContext`. Their associated type `Value` gurantees type-safety.
 /// To give your `BaggageContextKey` an explicit name you may override the `name` property.
 public protocol BaggageContextKey {

--- a/Tests/BaggageTests/BaggageContextTests.swift
+++ b/Tests/BaggageTests/BaggageContextTests.swift
@@ -27,6 +27,30 @@ final class BaggageContextTests: XCTestCase {
         baggage[TestIDKey.self] = nil
         XCTAssertNil(baggage.testID)
     }
+
+    func testEmptyBaggageDescription() {
+        XCTAssertEqual(String(describing: BaggageContext()), "BaggageContext(keys: [])")
+    }
+
+    func testSingleKeyBaggageDescription() {
+        var baggage = BaggageContext()
+        baggage.testID = 42
+
+        XCTAssertEqual(String(describing: baggage), #"BaggageContext(keys: ["TestIDKey"])"#)
+    }
+
+    func testMultiKeysBaggageDescription() {
+        var baggage = BaggageContext()
+        baggage.testID = 42
+        baggage[SecondTestIDKey.self] = "test"
+
+        let description = String(describing: baggage)
+        XCTAssert(description.starts(with: "BaggageContext(keys: ["))
+        // use contains instead of `XCTAssertEqual` because the order is non-predictable (Dictionary)
+        XCTAssert(description.contains("TestIDKey"))
+        XCTAssert(description.contains("ExplicitKeyName"))
+        print(description.reversed().starts(with: "])"))
+    }
 }
 
 private enum TestIDKey: BaggageContextKey {
@@ -41,4 +65,10 @@ private extension BaggageContext {
             self[TestIDKey.self] = newValue
         }
     }
+}
+
+private enum SecondTestIDKey: BaggageContextKey {
+    typealias Value = String
+
+    static let name: String? = "ExplicitKeyName"
 }


### PR DESCRIPTION
Closes #41 

With this in place, `BaggageLogging`s "hack" of storing the `Logger` in the `BaggageContext` feels even weirder, because the `BaseLoggerKey` is clearly readable in the output 🤔 (#37)