### PR TITLE
Remove macOS version requirement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,9 +3,6 @@ import PackageDescription
 
 let package = Package(
     name: "gsoc-swift-tracing",
-    platforms: [
-        .macOS(.v10_15)
-    ],
     products: [
         .library(name: "BaggageLogging", targets: ["BaggageLogging"]),
         .library(name: "Instrumentation", targets: ["Instrumentation"]),


### PR DESCRIPTION
This must have been leftover from poking around. I believe there's currently no reason to require a specific macOS version.