### PR TITLE
Expose public dictionary init for SpanAttributes

### DIFF
--- a/Sources/Instrumentation/Tracing/Span.swift
+++ b/Sources/Instrumentation/Tracing/Span.swift
@@ -165,6 +165,12 @@ extension SpanAttribute: ExpressibleByArrayLiteral {
 public struct SpanAttributes {
     private var _attributes = [String: SpanAttribute]()
 
+    /// Create a set of attributes by wrapping the given dictionary.
+    /// - Parameter attributes: The attributes dictionary to wrap.
+    public init(_ attributes: [String: SpanAttribute]) {
+        self._attributes = attributes
+    }
+
     /// Accesses the `SpanAttribute` with the given name for reading and writing.
     /// - Parameter name: The name of the attribute used to identify the attribute.
     /// - Returns: The `SpanAttribute` identified by the given name, or `nil` if it's not present.


### PR DESCRIPTION
In order to bridge other types (e.g. [`XRayRecorder.Segment.AnnotationValue`](https://github.com/slashmo/aws-xray-sdk-swift/blob/c11535e382be3052525ed9f4eef25f14b3ea89c5/Sources/AWSXRayRecorder/Segment.swift#L360)) we need to expose an additional initializer for `SpanAttributes` that takes a dictionary. Libraries bridging from their own `SpanAttribute`-like type to `SpanAttribute` may add an extension to `SpanAttribute` to bridge a single value, but in order for them to create a `SpanAttributes` (required in the `Span` protocol), it's currently only possible to initialize `SpanAttributes` with a dictionary literal.