### PR TITLE
Make SpanAttribute ExpressibleByStringInterpolation

### DIFF
--- a/Sources/Instrumentation/Tracing/Span.swift
+++ b/Sources/Instrumentation/Tracing/Span.swift
@@ -137,6 +137,12 @@ extension SpanAttribute: ExpressibleByStringLiteral {
     }
 }
 
+extension SpanAttribute: ExpressibleByStringInterpolation {
+    public init(stringInterpolation value: Self.StringInterpolation) {
+        self = .string("\(value)")
+    }
+}
+
 extension SpanAttribute: ExpressibleByIntegerLiteral {
     public init(integerLiteral value: Int) {
         self = .int(value)

--- a/Tests/InstrumentationTests/SpanTests.swift
+++ b/Tests/InstrumentationTests/SpanTests.swift
@@ -48,6 +48,15 @@ final class SpanTests: XCTestCase {
         XCTAssertEqual(stringValue, "test")
     }
 
+    func testSpanAttributeIsExpressibleByStringInterpolation() {
+        let stringAttribute: SpanAttribute = "test \(true) \(42) \(3.14)"
+        guard case .string(let stringValue) = stringAttribute else {
+            XCTFail("Expected string attribute, got \(stringAttribute).")
+            return
+        }
+        XCTAssertEqual(stringValue, "test true 42 3.14")
+    }
+
     func testSpanAttributeIsExpressibleByIntegerLiteral() {
         let intAttribute: SpanAttribute = 42
         guard case .int(let intValue) = intAttribute else {


### PR DESCRIPTION
metadata/attributes string values are rarely static string literals, more often they contain strings with computed values