### PR TITLE
!time define Timestamp backed by DispatchWallTime

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     "pins": [
       {
         "package": "swift-baggage-context",
-        "repositoryURL": "https://github.com/slashmo/gsoc-swift-baggage-context.git",
+        "repositoryURL": "https://github.com/slashmo/gsoc-swift-baggage-context",
         "state": {
           "branch": null,
-          "revision": "349804a0599573d09df6e433cb8266b80727e5b0",
+          "revision": "10469603494f1cde67fbd0725cdde0e04d131b05",
           "version": "0.1.0"
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     dependencies: [
         .package(
             name: "swift-baggage-context",
-            url: "https://github.com/slashmo/gsoc-swift-baggage-context.git",
+            url: "https://github.com/slashmo/gsoc-swift-baggage-context",
             from: "0.1.0"
         ),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.17.0"),

--- a/Sources/Instrumentation/Tracing/NoOpTracing.swift
+++ b/Sources/Instrumentation/Tracing/NoOpTracing.swift
@@ -12,7 +12,6 @@
 //===----------------------------------------------------------------------===//
 
 import Baggage
-import Dispatch
 
 /// No operation TracingInstrument, used when no tracing is required.
 public struct NoOpTracingInstrument: TracingInstrument {
@@ -20,7 +19,7 @@ public struct NoOpTracingInstrument: TracingInstrument {
         named operationName: String,
         context: BaggageContext,
         ofKind kind: SpanKind,
-        at timestamp: DispatchTime?
+        at timestamp: Timestamp?
     ) -> Span {
         NoOpSpan()
     }
@@ -40,11 +39,11 @@ public struct NoOpTracingInstrument: TracingInstrument {
         public var status: SpanStatus?
         public let kind: SpanKind = .internal
 
-        public var startTimestamp: DispatchTime {
+        public var startTimestamp: Timestamp {
             .now()
         }
 
-        public var endTimestamp: DispatchTime? = nil
+        public var endTimestamp: Timestamp?
 
         public var baggage: BaggageContext {
             .init()
@@ -65,7 +64,7 @@ public struct NoOpTracingInstrument: TracingInstrument {
 
         public let isRecording = false
 
-        public mutating func end(at timestamp: DispatchTime) {
+        public mutating func end(at timestamp: Timestamp) {
             // ignore
         }
     }

--- a/Sources/Instrumentation/Tracing/Span.swift
+++ b/Sources/Instrumentation/Tracing/Span.swift
@@ -12,7 +12,6 @@
 //===----------------------------------------------------------------------===//
 
 import Baggage
-import Dispatch
 
 /// A `Span` type that follows the OpenTracing/OpenTelemetry spec. The span itself should not be
 /// initializable via its public interface. `Span` creation should instead go through `tracer.startSpan`
@@ -30,11 +29,11 @@ public protocol Span {
     /// The status of this span.
     var status: SpanStatus? { get set }
 
-    /// The precise `DispatchTime` of when the `Span` was started.
-    var startTimestamp: DispatchTime { get }
+    /// The `Timestamp` of when the `Span` was started.
+    var startTimestamp: Timestamp { get }
 
-    /// The precise `DispatchTime` of when the `Span` has ended.
-    var endTimestamp: DispatchTime? { get }
+    /// The `Timestamp` of when the `Span` has ended.
+    var endTimestamp: Timestamp? { get }
 
     /// The read-only `BaggageContext` of this `Span`, set when starting this `Span`.
     var baggage: BaggageContext { get }
@@ -54,8 +53,8 @@ public protocol Span {
     mutating func addLink(_ link: SpanLink)
 
     /// End this `Span` at the given timestamp.
-    /// - Parameter timestamp: The `DispatchTime` at which the span ended.
-    mutating func end(at timestamp: DispatchTime)
+    /// - Parameter timestamp: The `Timestamp` at which the span ended.
+    mutating func end(at timestamp: Timestamp)
 }
 
 extension Span {
@@ -77,7 +76,7 @@ extension Span {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Span Event
 
-/// An event that occured during a `Span`.
+/// An event that occurred during a `Span`.
 public struct SpanEvent {
     /// The human-readable name of this `SpanEvent`.
     public let name: String
@@ -85,15 +84,15 @@ public struct SpanEvent {
     /// One or more `SpanAttribute`s with the same restrictions as defined for `Span` attributes.
     public var attributes: SpanAttributes
 
-    /// The `DispatchTime` at which this event occured.
-    public let timestamp: DispatchTime
+    /// The `Timestamp` at which this event occurred.
+    public let timestamp: Timestamp
 
     /// Create a new `SpanEvent`.
     /// - Parameters:
     ///   - name: The human-readable name of this event.
-    ///   - attributes: The `SpanAttributes` describing this event. Defaults to no attributes.
-    ///   - timestamp: The `DispatchTime` at which this event occured. Defaults to `.now()`.
-    public init(name: String, attributes: SpanAttributes = [:], at timestamp: DispatchTime = .now()) {
+    ///   - attributes: attributes describing this event. Defaults to no attributes.
+    ///   - timestamp: The `Timestamp` at which this event occurred. Defaults to `.now()`.
+    public init(name: String, attributes: SpanAttributes = [:], at timestamp: Timestamp = .now()) {
         self.name = name
         self.attributes = attributes
         self.timestamp = timestamp
@@ -116,7 +115,7 @@ public enum SpanAttribute {
     case double(Double)
     case bool(Bool)
 
-    // TODO: This could be misused to create a heterogenuous array of attributes, which is not allowed in OT:
+    // TODO: This could be misused to create a heterogeneous array of attributes, which is not allowed in OT:
     // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-attributes
 
     case array([SpanAttribute])
@@ -203,15 +202,15 @@ extension SpanAttributes: ExpressibleByDictionaryLiteral {
 
 /// Represents the status of a finished Span. It's composed of a canonical code in conjunction with an optional descriptive message.
 public struct SpanStatus {
-    public let cannonicalCode: CannonicalCode
+    public let canonicalCode: CannonicalCode
     public let message: String?
 
     /// Create a new `SpanStatus`.
     /// - Parameters:
-    ///   - cannonicalCode: The cannonical code of this `SpanStatus`.
+    ///   - canonicalCode: The canonical code of this `SpanStatus`.
     ///   - message: The optional descriptive message of this `SpanStatus`. Defaults to nil.
-    public init(cannonicalCode: CannonicalCode, message: String? = nil) {
-        self.cannonicalCode = cannonicalCode
+    public init(canonicalCode: CannonicalCode, message: String? = nil) {
+        self.canonicalCode = canonicalCode
         self.message = message
     }
 

--- a/Sources/Instrumentation/Tracing/Timestamp.swift
+++ b/Sources/Instrumentation/Tracing/Timestamp.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Tracing open source project
+//
+// Copyright (c) 2020 Moritz Lang and the Swift Tracing project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+import Darwin
+#else
+import Glibc
+#endif
+
+/// Represents a wall-clock time with microsecond precision.
+public struct Timestamp: Comparable, CustomStringConvertible {
+    private let time: DispatchWallTime
+
+    /// Microseconds since Epoch
+    public var microsSinceEpoch: Int64 {
+        Int64(bitPattern: self.time.rawValue) / -1000
+    }
+
+    /// Milliseconds since Epoch
+    public var millisSinceEpoch: Int64 {
+        Int64(bitPattern: self.time.rawValue) / -1_000_000
+    }
+
+    /// Returns the current time.
+    public static func now() -> Timestamp {
+        self.init(time: .now())
+    }
+
+    /// A time in the distant future.
+    public static let distantFuture: Timestamp = .init(time: .distantFuture)
+
+    public init(millisSinceEpoch: Int64) {
+        let nanoSinceEpoch = UInt64(millisSinceEpoch) * 1_000_000
+        let seconds = UInt64(nanoSinceEpoch / 1_000_000_000)
+        let nanoseconds = nanoSinceEpoch - (seconds * 1_000_000_000)
+        self.init(time: DispatchWallTime(timespec: timespec(tv_sec: Int(seconds), tv_nsec: Int(nanoseconds))))
+    }
+
+    public init(time: DispatchWallTime) {
+        self.time = time
+    }
+
+    public var description: String {
+        "Timestamp(\(self.time.rawValue))"
+    }
+
+    public static func < (lhs: Timestamp, rhs: Timestamp) -> Bool {
+        lhs.time < rhs.time
+    }
+
+    public static func == (lhs: Timestamp, rhs: Timestamp) -> Bool {
+        lhs.time == rhs.time
+    }
+}

--- a/Sources/Instrumentation/Tracing/TracingInstrument.swift
+++ b/Sources/Instrumentation/Tracing/TracingInstrument.swift
@@ -12,7 +12,6 @@
 //===----------------------------------------------------------------------===//
 
 import Baggage
-import Dispatch
 
 /// An `Instrument` with added functionality for distributed tracing. Is uses the span-based tracing model and is
 /// based on the OpenTracing/OpenTelemetry spec.
@@ -27,7 +26,7 @@ public protocol TracingInstrument: Instrument {
         named operationName: String,
         context: BaggageContext,
         ofKind kind: SpanKind,
-        at timestamp: DispatchTime?
+        at timestamp: Timestamp?
     ) -> Span
 }
 
@@ -42,7 +41,7 @@ extension TracingInstrument {
     public func startSpan(
         named operationName: String,
         context: BaggageContext,
-        at timestamp: DispatchTime? = nil
+        at timestamp: Timestamp? = nil
     ) -> Span {
         self.startSpan(named: operationName, context: context, ofKind: .internal, at: nil)
     }

--- a/Tests/InstrumentationTests/Tracing/TimestampTests.swift
+++ b/Tests/InstrumentationTests/Tracing/TimestampTests.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Tracing open source project
+//
+// Copyright (c) 2020 Moritz Lang and the Swift Tracing project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Instrumentation
+import XCTest
+
+final class TimestampTests: XCTestCase {
+    func test_timestamp_now() {
+        let timestamp = Timestamp.now()
+        XCTAssertGreaterThan(timestamp.microsSinceEpoch, 1_595_592_205_693_986)
+        XCTAssertGreaterThan(timestamp.millisSinceEpoch, 1_595_592_205_693)
+    }
+}

--- a/Tests/InstrumentationTests/Tracing/TracedLockTests.swift
+++ b/Tests/InstrumentationTests/Tracing/TracedLockTests.swift
@@ -57,7 +57,7 @@ private final class TracedLockPrintlnTracer: TracingInstrument {
         named operationName: String,
         context: BaggageContext,
         ofKind kind: SpanKind,
-        at timestamp: DispatchTime?
+        at timestamp: Timestamp?
     ) -> Span {
         TracedLockPrintlnSpan(
             operationName: operationName,
@@ -87,8 +87,8 @@ private final class TracedLockPrintlnTracer: TracingInstrument {
             }
         }
 
-        let startTimestamp: DispatchTime
-        private(set) var endTimestamp: DispatchTime?
+        let startTimestamp: Timestamp
+        private(set) var endTimestamp: Timestamp?
 
         let baggage: BaggageContext
 
@@ -110,7 +110,7 @@ private final class TracedLockPrintlnTracer: TracingInstrument {
 
         init(
             operationName: String,
-            startTimestamp: DispatchTime,
+            startTimestamp: Timestamp,
             kind: SpanKind,
             context baggage: BaggageContext
         ) {
@@ -130,9 +130,9 @@ private final class TracedLockPrintlnTracer: TracingInstrument {
             self.events.append(event)
         }
 
-        mutating func end(at timestamp: DispatchTime) {
+        mutating func end(at timestamp: Timestamp) {
             self.endTimestamp = timestamp
-            print("     span [\(self.operationName): \(self.baggage[TaskIDKey.self] ?? "no-name")] @ \(timestamp): end (took \(timestamp.uptimeNanoseconds - self.startTimestamp.uptimeNanoseconds) nanos)")
+            print("     span [\(self.operationName): \(self.baggage[TaskIDKey.self] ?? "no-name")] @ \(timestamp): end")
         }
     }
 }

--- a/Tests/InstrumentationTests/TracingInstrumentTests.swift
+++ b/Tests/InstrumentationTests/TracingInstrumentTests.swift
@@ -13,7 +13,6 @@
 
 import Baggage
 import BaggageLogging
-import Dispatch
 import Instrumentation
 import XCTest
 
@@ -36,7 +35,7 @@ final class JaegerTracer: TracingInstrument {
         named operationName: String,
         context: BaggageContext,
         ofKind kind: SpanKind,
-        at timestamp: DispatchTime?
+        at timestamp: Timestamp?
     ) -> Span {
         let span = OTSpan(
             operationName: operationName,
@@ -101,8 +100,8 @@ struct OTSpan: Span {
         }
     }
 
-    let startTimestamp: DispatchTime
-    private(set) var endTimestamp: DispatchTime?
+    let startTimestamp: Timestamp
+    private(set) var endTimestamp: Timestamp?
 
     let baggage: BaggageContext
 
@@ -126,7 +125,7 @@ struct OTSpan: Span {
 
     init(
         operationName: String,
-        startTimestamp: DispatchTime,
+        startTimestamp: Timestamp,
         context baggage: BaggageContext,
         kind: SpanKind,
         onEnd: @escaping (Span) -> Void
@@ -146,7 +145,7 @@ struct OTSpan: Span {
         self.events.append(event)
     }
 
-    mutating func end(at timestamp: DispatchTime) {
+    mutating func end(at timestamp: Timestamp) {
         self.endTimestamp = timestamp
         self.onEnd(self)
     }

--- a/scripts/validate_license_headers.sh
+++ b/scripts/validate_license_headers.sh
@@ -109,7 +109,8 @@ EOF
   (
     cd "$here/.."
     find . \
-      \( \! -path './.build/*' -a \
+      \( \! -path './UseCases/.build/*' -a \
+      \( \! -path './.build/*' \) -a \
       \( "${matching_files[@]}" \) -a \
       \( \! \( "${exceptions[@]}" \) \) \) | while read line; do
       if [[ "$(cat "$line" | replace_acceptable_years | head -n $expected_lines | shasum)" != "$expected_sha" ]]; then


### PR DESCRIPTION
Fixes two things:

- we used the wrong dispatch time, thanks @pokryfka for spotting this
- it should not be necessary to import Dispatch just to use the tracing instruments; thus introduced a Timestamp type backed by dispatch.