### PR TITLE
Export OpenTelemetryInstrumentationSupport library 📦

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
         .library(name: "BaggageLogging", targets: ["BaggageLogging"]),
         .library(name: "Instrumentation", targets: ["Instrumentation"]),
         .library(name: "TracingInstrumentation", targets: ["TracingInstrumentation"]),
-        .library(name: "NIOInstrumentation", targets: ["NIOInstrumentation"])
+        .library(name: "NIOInstrumentation", targets: ["NIOInstrumentation"]),
+        .library(name: "OpenTelemetryInstrumentationSupport", targets: ["OpenTelemetryInstrumentationSupport"])
     ],
     dependencies: [
         .package(


### PR DESCRIPTION
`OpenTelemetryInstrumentationSupport` cannot be used because it's not defined as a product in the package file. This PR changes that.