### PR TITLE
Fix NIO & HTTP Client version clash in UseCases 📦

### DIFF
--- a/UseCases/Package.resolved
+++ b/UseCases/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "7cd24c0efcf9700033f671b6a8eaa64a77dd0b72",
-          "version": "1.5.1"
+          "revision": "d525d3bbd1321fa928948065fd9a8dc109d5d45b",
+          "version": "1.6.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "f0b118d9af6c4e78bc4f3f4fbb464020172b0bf4",
-          "version": "2.7.5"
+          "revision": "8a137b72a9339f295bc8bb95cd2fafe207f1df0d",
+          "version": "2.9.0"
         }
       }
     ]

--- a/UseCases/Package.swift
+++ b/UseCases/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     dependencies: [
         .package(name: "gsoc-swift-tracing", path: "../"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.1.1"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.18.0")
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.9.0"),
     ],
     targets: [
         .target(name: "ManualContextPropagation", dependencies: [
@@ -20,14 +20,15 @@ let package = Package(
         .target(name: "ManualAsyncHTTPClient", dependencies: [
             .product(name: "Instrumentation", package: "gsoc-swift-tracing"),
             .product(name: "NIOInstrumentation", package: "gsoc-swift-tracing"),
-            .product(name: "AsyncHTTPClient", package: "async-http-client")
+            .product(name: "AsyncHTTPClient", package: "async-http-client"),
+            .product(name: "NIO", package: "swift-nio"),
         ]),
         .target(name: "HTTPEndToEnd", dependencies: [
             .product(name: "BaggageLogging", package: "gsoc-swift-tracing"),
             .product(name: "Instrumentation", package: "gsoc-swift-tracing"),
             .product(name: "NIOInstrumentation", package: "gsoc-swift-tracing"),
             .product(name: "AsyncHTTPClient", package: "async-http-client"),
-            .product(name: "NIO", package: "swift-nio")
+            .product(name: "NIO", package: "swift-nio"),
         ])
     ]
 )


### PR DESCRIPTION
Having both `NIO` & `AsyncHTTPClient` as explicit dependencies made the resolution fail.