### PR TITLE
Add recordError method to Span

### DIFF
--- a/Sources/TracingInstrumentation/NoOpTracingInstrument.swift
+++ b/Sources/TracingInstrumentation/NoOpTracingInstrument.swift
@@ -54,6 +54,8 @@ public struct NoOpTracingInstrument: TracingInstrument {
 
         public mutating func addEvent(_ event: SpanEvent) {}
 
+        public func recordError(_ error: Error) {}
+
         public var attributes: SpanAttributes {
             get {
                 [:]

--- a/Sources/TracingInstrumentation/Span.swift
+++ b/Sources/TracingInstrumentation/Span.swift
@@ -41,6 +41,12 @@ public protocol Span {
     /// - Parameter event: The `SpanEvent` to add to this `Span`.
     mutating func addEvent(_ event: SpanEvent)
 
+    /// Record an error of the given type described by the the given message.
+    ///
+    /// - Parameters:
+    ///   - error: The error to be recorded.
+    mutating func recordError(_ error: Error)
+
     /// The attributes describing this `Span`.
     var attributes: SpanAttributes { get set }
 
@@ -83,7 +89,7 @@ extension Span {
 // MARK: Span Event
 
 /// An event that occurred during a `Span`.
-public struct SpanEvent {
+public struct SpanEvent: Equatable {
     /// The human-readable name of this `SpanEvent`.
     public let name: String
 
@@ -299,7 +305,7 @@ extension SpanAttribute: ExpressibleByArrayLiteral {
 
 /// A collection of `SpanAttribute`s.
 @dynamicMemberLookup
-public struct SpanAttributes {
+public struct SpanAttributes: Equatable {
     private var _attributes = [String: SpanAttribute]()
 
     /// Create a set of attributes by wrapping the given dictionary.

--- a/Tests/TracingInstrumentationTests/TracedLockTests.swift
+++ b/Tests/TracingInstrumentationTests/TracedLockTests.swift
@@ -131,6 +131,8 @@ private final class TracedLockPrintlnTracer: TracingInstrument {
             self.events.append(event)
         }
 
+        func recordError(_ error: Error) {}
+
         mutating func end(at timestamp: Timestamp) {
             self.endTimestamp = timestamp
             print("     span [\(self.operationName): \(self.context[TaskIDKey.self] ?? "no-name")] @ \(timestamp): end")

--- a/Tests/TracingInstrumentationTests/TracingInstrumentTests.swift
+++ b/Tests/TracingInstrumentationTests/TracingInstrumentTests.swift
@@ -168,6 +168,8 @@ struct TestSpan: Span {
         self.events.append(event)
     }
 
+    func recordError(_ error: Error) {}
+
     mutating func end(at timestamp: Timestamp) {
         self.endTimestamp = timestamp
         self.onEnd(self)


### PR DESCRIPTION
Adds `recordError(type:String?,message:String?)` to `Span` with default implementation to record errors as `SpanEvent`s.

Closes #90 