### PR TITLE
Add (g)RPC semantic attributes

### DIFF
--- a/Sources/OpenTelemetryInstrumentationSupport/SpanAttribute+GRPCSemantics.swift
+++ b/Sources/OpenTelemetryInstrumentationSupport/SpanAttribute+GRPCSemantics.swift
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Tracing open source project
+//
+// Copyright (c) 2020 Moritz Lang and the Swift Tracing project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import TracingInstrumentation
+
+extension SpanAttributeName {
+    /// - See: GRPCAttributes
+    public static let gRPCMessageType = "message.type"
+    /// - See: GRPCAttributes
+    public static let gRPCMessageID = "message.id"
+    /// - See: GRPCAttributes
+    public static let gRPCMessageCompressedSize = "message.compressed_size"
+    /// - See: GRPCAttributes
+    public static let gRPCMessageUncompressedSize = "message.uncompressed_size"
+}
+
+#if swift(>=5.2)
+extension SpanAttributes {
+    /// Semantic conventions for gRPC spans.
+    public var gRPC: GRPCAttributes {
+        get {
+            .init(attributes: self)
+        }
+        set {
+            self = newValue.attributes
+        }
+    }
+}
+
+/// Semantic conventions for gRPC spans as defined in the OpenTelemetry spec.
+///
+/// - SeeAlso: [OpenTelemetry: Semantic conventions for gRPC spans](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/rpc.md#grpc) (as of August 2020)
+@dynamicMemberLookup
+public struct GRPCAttributes: SpanAttributeNamespace {
+    public var attributes: SpanAttributes
+
+    public init(attributes: SpanAttributes) {
+        self.attributes = attributes
+    }
+
+    public struct NestedAttributes: NestedSpanAttributesProtocol {
+        public init() {}
+
+        /// The type of message, e.g. "SENT" or "RECEIVED".
+        public var messageType: SpanAttributeKey<String> { .init(name: SpanAttributeName.gRPCMessageType) }
+
+        /// The message id calculated as two different counters starting from 1, one for sent messages and one for received messages.
+        public var messageID: SpanAttributeKey<Int> { .init(name: SpanAttributeName.gRPCMessageID) }
+
+        /// The compressed message size in bytes.
+        public var messageCompressedSize: SpanAttributeKey<Int> {
+            .init(name: SpanAttributeName.gRPCMessageCompressedSize)
+        }
+
+        /// The uncompressed message size in bytes.
+        public var messageUncompressedSize: SpanAttributeKey<Int> {
+            .init(name: SpanAttributeName.gRPCMessageUncompressedSize)
+        }
+    }
+}
+#endif

--- a/Sources/OpenTelemetryInstrumentationSupport/SpanAttribute+GRPCSemantics.swift
+++ b/Sources/OpenTelemetryInstrumentationSupport/SpanAttribute+GRPCSemantics.swift
@@ -15,13 +15,16 @@ import TracingInstrumentation
 
 extension SpanAttributeName {
     /// - See: GRPCAttributes
-    public static let gRPCMessageType = "message.type"
-    /// - See: GRPCAttributes
-    public static let gRPCMessageID = "message.id"
-    /// - See: GRPCAttributes
-    public static let gRPCMessageCompressedSize = "message.compressed_size"
-    /// - See: GRPCAttributes
-    public static let gRPCMessageUncompressedSize = "message.uncompressed_size"
+    public enum GRPC {
+        /// - See: GRPCAttributes
+        public static let messageType = "message.type"
+        /// - See: GRPCAttributes
+        public static let messageID = "message.id"
+        /// - See: GRPCAttributes
+        public static let messageCompressedSize = "message.compressed_size"
+        /// - See: GRPCAttributes
+        public static let messageUncompressedSize = "message.uncompressed_size"
+    }
 }
 
 #if swift(>=5.2)
@@ -52,19 +55,19 @@ public struct GRPCAttributes: SpanAttributeNamespace {
         public init() {}
 
         /// The type of message, e.g. "SENT" or "RECEIVED".
-        public var messageType: SpanAttributeKey<String> { .init(name: SpanAttributeName.gRPCMessageType) }
+        public var messageType: SpanAttributeKey<String> { .init(name: SpanAttributeName.GRPC.messageType) }
 
         /// The message id calculated as two different counters starting from 1, one for sent messages and one for received messages.
-        public var messageID: SpanAttributeKey<Int> { .init(name: SpanAttributeName.gRPCMessageID) }
+        public var messageID: SpanAttributeKey<Int> { .init(name: SpanAttributeName.GRPC.messageID) }
 
         /// The compressed message size in bytes.
         public var messageCompressedSize: SpanAttributeKey<Int> {
-            .init(name: SpanAttributeName.gRPCMessageCompressedSize)
+            .init(name: SpanAttributeName.GRPC.messageCompressedSize)
         }
 
         /// The uncompressed message size in bytes.
         public var messageUncompressedSize: SpanAttributeKey<Int> {
-            .init(name: SpanAttributeName.gRPCMessageUncompressedSize)
+            .init(name: SpanAttributeName.GRPC.messageUncompressedSize)
         }
     }
 }

--- a/Sources/OpenTelemetryInstrumentationSupport/SpanAttribute+RPCSemantics.swift
+++ b/Sources/OpenTelemetryInstrumentationSupport/SpanAttribute+RPCSemantics.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Tracing open source project
+//
+// Copyright (c) 2020 Moritz Lang and the Swift Tracing project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import TracingInstrumentation
+
+extension SpanAttributeName {
+    /// - See: RPCAttributes
+    public static let rpcSystem = "rpc.system"
+    /// - See: RPCAttributes
+    public static let rpcService = "rpc.service"
+    /// - See: RPCAttributes
+    public static let rpcMethod = "rpc.method"
+}
+
+#if swift(>=5.2)
+extension SpanAttributes {
+    /// Semantic conventions for RPC spans.
+    public var rpc: RPCAttributes {
+        get {
+            .init(attributes: self)
+        }
+        set {
+            self = newValue.attributes
+        }
+    }
+}
+
+/// Semantic conventions for RPC spans as defined in the OpenTelemetry spec.
+///
+/// - SeeAlso: [OpenTelemetry: Semantic conventions for RPC spans](https://github.com/open-telemetry/opentelemetry-specification/blob/b70565d5a8a13d26c91fb692879dc874d22c3ac8/specification/trace/semantic_conventions/rpc.md) (as of August 2020)
+@dynamicMemberLookup
+public struct RPCAttributes: SpanAttributeNamespace {
+    public var attributes: SpanAttributes
+
+    public init(attributes: SpanAttributes) {
+        self.attributes = attributes
+    }
+
+    public struct NestedAttributes: NestedSpanAttributesProtocol {
+        public init() {}
+
+        /// A string identifying the remoting system, e.g., "grpc", "java_rmi" or "wcf".
+        public var system: SpanAttributeKey<String> { .init(name: SpanAttributeName.rpcSystem) }
+
+        /// The full name of the service being called, including its package name, if applicable.
+        public var service: SpanAttributeKey<String> { .init(name: SpanAttributeName.rpcService) }
+
+        /// The name of the method being called, must be equal to the $method part in the span name.
+        public var method: SpanAttributeKey<String> { .init(name: SpanAttributeName.rpcMethod) }
+    }
+}
+#endif

--- a/Sources/OpenTelemetryInstrumentationSupport/SpanAttribute+RPCSemantics.swift
+++ b/Sources/OpenTelemetryInstrumentationSupport/SpanAttribute+RPCSemantics.swift
@@ -15,11 +15,14 @@ import TracingInstrumentation
 
 extension SpanAttributeName {
     /// - See: RPCAttributes
-    public static let rpcSystem = "rpc.system"
-    /// - See: RPCAttributes
-    public static let rpcService = "rpc.service"
-    /// - See: RPCAttributes
-    public static let rpcMethod = "rpc.method"
+    public enum RPC {
+        /// - See: RPCAttributes
+        public static let system = "rpc.system"
+        /// - See: RPCAttributes
+        public static let service = "rpc.service"
+        /// - See: RPCAttributes
+        public static let method = "rpc.method"
+    }
 }
 
 #if swift(>=5.2)
@@ -50,13 +53,13 @@ public struct RPCAttributes: SpanAttributeNamespace {
         public init() {}
 
         /// A string identifying the remoting system, e.g., "grpc", "java_rmi" or "wcf".
-        public var system: SpanAttributeKey<String> { .init(name: SpanAttributeName.rpcSystem) }
+        public var system: SpanAttributeKey<String> { .init(name: SpanAttributeName.RPC.system) }
 
         /// The full name of the service being called, including its package name, if applicable.
-        public var service: SpanAttributeKey<String> { .init(name: SpanAttributeName.rpcService) }
+        public var service: SpanAttributeKey<String> { .init(name: SpanAttributeName.RPC.service) }
 
         /// The name of the method being called, must be equal to the $method part in the span name.
-        public var method: SpanAttributeKey<String> { .init(name: SpanAttributeName.rpcMethod) }
+        public var method: SpanAttributeKey<String> { .init(name: SpanAttributeName.RPC.method) }
     }
 }
 #endif


### PR DESCRIPTION
Adds an `rpc` namespace with the semantic span attributes as defined in the OTel Spec: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/rpc.md#events