### PR TITLE
Return nil when extracting empty header value

### DIFF
--- a/Sources/NIOInstrumentation/HTTPHeadersCarrier.swift
+++ b/Sources/NIOInstrumentation/HTTPHeadersCarrier.swift
@@ -23,11 +23,11 @@ public struct HTTPHeadersExtractor: ExtractorProtocol {
     public init() {}
 
     public func extract(key: String, from headers: HTTPHeaders) -> String? {
-        return headers
+        let headers = headers
             .lazy
             .filter { $0.name == key }
             .map { $0.value }
-            .joined(separator: ",")
+        return headers.isEmpty ? nil : headers.joined(separator: ",")
     }
 }
 

--- a/Tests/NIOInstrumentationTests/HTTPHeadersCarrierTests+XCTest.swift
+++ b/Tests/NIOInstrumentationTests/HTTPHeadersCarrierTests+XCTest.swift
@@ -26,6 +26,7 @@ extension HTTPHeadersCarrierTests {
    static var allTests : [(String, (HTTPHeadersCarrierTests) -> () throws -> Void)] {
       return [
                 ("testExtractSingleHeader", testExtractSingleHeader),
+                ("testExtractNoHeader", testExtractNoHeader),
                 ("testExtractMultipleHeadersOfSameName", testExtractMultipleHeadersOfSameName),
            ]
    }

--- a/Tests/NIOInstrumentationTests/HTTPHeadersCarrierTests.swift
+++ b/Tests/NIOInstrumentationTests/HTTPHeadersCarrierTests.swift
@@ -35,6 +35,18 @@ final class HTTPHeadersCarrierTests: XCTestCase {
         )
     }
 
+    func testExtractNoHeader() {
+        let extractor = HTTPHeadersExtractor()
+
+        XCTAssertNil(extractor.extract(key: "test", from: .init()))
+    }
+
+    func testExtractEmptyHeader() {
+        let extractor = HTTPHeadersExtractor()
+
+        XCTAssertEqual(extractor.extract(key: "test", from: ["test": ""]), "")
+    }
+
     func testExtractMultipleHeadersOfSameName() {
         let headers: HTTPHeaders = [
             "tracestate": "vendorname1=opaqueValue1",


### PR DESCRIPTION
Due to the changes introduced in #146, when `HTTPHeadersExtractor` extracts no headers, it returns an empty string instead of `nil`, which may lead to slight misbehavior for users of this API.